### PR TITLE
Add several tests to bedrock-agreements and make small API change.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,8 @@ api.accept = function(actor, agreements, callback) {
  */
 api.getAccepted = function(actor, identityId, callback) {
   if(!actor || !('id' in actor)) {
-    return callback(new Error('actor is not a valid identity.'));
+    return callback(new TypeError(
+      'actor must be an object with an "id" property.'));
   }
   var query = {
     typeSpecific: database.hash(identityId),
@@ -99,7 +100,8 @@ api.getAccepted = function(actor, identityId, callback) {
         var rValue = records.reduce(function(a, b) {
           return a.concat(b.event.resource);
         }, []);
-        callback(null, rValue);
+        // during callback, make sure rValue has unique values only
+        callback(null, Array.from(new Set(rValue)));
       });
     }]
   }, function(err, results) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,15 +11,9 @@ var bedrock = require('bedrock');
 var brPermission = require('bedrock-permission');
 var database = require('bedrock-mongodb');
 var eventLog = require('bedrock-event-log').log;
-var BedrockError = bedrock.util.BedrockError;
-var uuid = require('uuid').v4;
 
 // load config defaults
 require('./config');
-
-bedrock.events.on('bedrock.test.configure', function() {
-  require('./test.config');
-});
 
 // module permissions
 var PERMISSIONS = bedrock.config.permission.permissions;

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2016 Digital Bazaar, Inc. All rights reserved.
  */
-/* globals describe, before, after, it, should, beforeEach, afterEach */
+/* globals describe, it, should, beforeEach */
 /* jshint node: true */
 'use strict';
 
 var async = require('async');
 var bedrock = require('bedrock');
-var brAgreement = require('../..');
+var brAgreement = require('bedrock-agreement');
 var database = require('bedrock-mongodb');
 var helpers = require('./helpers');
 var mockData = require('./mock.data');
@@ -87,7 +87,6 @@ describe('bedrock-agreement', function() {
       }, done);
     });
 
-    // tests that accept API does not reject duplicates
     it('accepts two identical agreements specified as strings', function(done) {
       var agreementsAlpha = uuid();
       var agreementsBeta = agreementsAlpha;
@@ -105,7 +104,7 @@ describe('bedrock-agreement', function() {
             callback(err, result);
           });
         },
-        testBoth: ['insertAlpha', 'insertBeta', function(callback, results) {
+        testBoth: ['insertAlpha', 'insertBeta', function(callback) {
           database.collections.eventLog.find({
             'event.type': 'AgreementAccept',
             typeSpecific: database.hash(actor.id)

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -19,7 +19,7 @@ describe('bedrock-agreement', function() {
       helpers.removeCollection('eventLog', done);
     });
 
-    it('adds an event for one agreement specified as a string', function(done) {
+    it('accepts one agreement specified as a string', function(done) {
       var agreements = uuid();
       var actor = mockData.identities.regularUser.identity;
       async.auto({
@@ -49,7 +49,6 @@ describe('bedrock-agreement', function() {
             should.exist(event.date);
             event.date.should.be.a('string');
             should.exist(event.resource);
-            event.resource.should.be.an('array');
             event.resource.should.have.length(1);
             event.resource[0].should.equal(agreements);
             should.exist(event.actor);
@@ -61,7 +60,8 @@ describe('bedrock-agreement', function() {
         }]
       }, done);
     });
-    it('adds event for four agreements specified as an array', function(done) {
+
+    it('accepts four agreements specified as an array', function(done) {
       var agreements = [];
       for(var i = 0; i < 4; i++) {
         agreements.push(uuid());
@@ -86,6 +86,66 @@ describe('bedrock-agreement', function() {
         }]
       }, done);
     });
+
+    // tests that accept API does not reject duplicates
+    it('accepts two identical agreements specified as strings', function(done) {
+      var agreementsAlpha = uuid();
+      var agreementsBeta = agreementsAlpha;
+      var actor = mockData.identities.regularUser.identity;
+      async.auto({
+        insertAlpha: function(callback) {
+          brAgreement.accept(actor, agreementsAlpha, function(err, result) {
+            should.not.exist(err);
+            callback(err, result);
+          });
+        },
+        insertBeta: function(callback) {
+          brAgreement.accept(actor, agreementsBeta, function(err, result) {
+            should.not.exist(err);
+            callback(err, result);
+          });
+        },
+        testBoth: ['insertAlpha', 'insertBeta', function(callback, results) {
+          database.collections.eventLog.find({
+            'event.type': 'AgreementAccept',
+            typeSpecific: database.hash(actor.id)
+          }).toArray(function(err, result) {
+            should.not.exist(err);
+            result.should.have.length(2);
+            var event0 = result[0].event;
+            var event1 = result[1].event;
+            event0.resource[0].should.equal(agreementsAlpha);
+            event1.resource[0].should.equal(agreementsAlpha);
+            callback();
+          });
+        }]
+      }, done);
+    });
+
+    // tests that accept API does not reject duplicates in an array
+    it('accepts five agreements w/ same ID in an array', function(done) {
+      var agreementsID = uuid();
+      var agreements = Array(5).fill(agreementsID);
+      var actor = mockData.identities.regularUser.identity;
+      async.auto({
+        insert: function(callback) {
+          brAgreement.accept(actor, agreements, callback);
+        },
+        test: ['insert', function(callback, results) {
+          database.collections.eventLog.find({
+            'event.id': results.insert.event.id
+          }).toArray(function(err, result) {
+            should.not.exist(err);
+            var event = result[0].event;
+            should.exist(event.resource);
+            event.resource.should.have.length(5);
+            event.resource.should.deep.equal(agreements);
+            callback();
+          });
+        }]
+      }, done);
+    });
+
     it('returns error if no AGREEMENT_ACCEPT permission', function(done) {
       var agreements = uuid();
       var actor = mockData.identities.noPermission.identity;
@@ -96,13 +156,47 @@ describe('bedrock-agreement', function() {
         done();
       });
     });
-    it('returns an error if agreements is not a string or array');
-    it('returns an error if actor is not a valid identity');
+
+    it('returns error if agreements is not a string or array', function(done) {
+      var agreements = null; // agreement that is neither a string or an array
+      var actor = mockData.identities.regularUser.identity;
+      brAgreement.accept(actor, agreements, function(err) {
+        should.exist(err);
+        err.toString().should.equal(
+          'TypeError: agreements parameter must be a string or an array.');
+        done();
+      });
+    });
+
+    it('returns an error if actor is not a valid identity', function(done) {
+      var agreements = null; // agreement that is neither a string or an array
+      brAgreement.accept(null, agreements, function(err) {
+        should.exist(err);
+        err.toString().should.equal(
+          'TypeError: actor must be an object with an "id" property.');
+        done();
+      });
+    });
+
   }); // end add
 
   describe('getAccepted API', function() {
     beforeEach(function(done) {
       helpers.removeCollection('eventLog', done);
+    });
+
+    it('returns empty array from no events', function(done) {
+      var actor = mockData.identities.regularUser.identity;
+      async.auto({
+        getAccepted: function(callback) {
+          brAgreement.getAccepted(actor, actor.id, callback);
+        },
+        test: ['getAccepted', function(callback, results) {
+          var result = results.getAccepted;
+          result.should.have.length(0);
+          callback();
+        }]
+      }, done);
     });
 
     it('returns one agreement from one event', function(done) {
@@ -117,13 +211,13 @@ describe('bedrock-agreement', function() {
         }],
         test: ['getAccepted', function(callback, results) {
           var result = results.getAccepted;
-          result.should.be.an('array');
           result.should.have.length(1);
           result.should.include(agreements);
           callback();
         }]
       }, done);
     });
+
     it('returns four agreements from one event', function(done) {
       var agreements = [];
       for(var i = 0; i < 4; i++) {
@@ -139,13 +233,13 @@ describe('bedrock-agreement', function() {
         }],
         test: ['getAccepted', function(callback, results) {
           var result = results.getAccepted;
-          result.should.be.an('array');
           result.should.have.length(4);
           result.should.deep.equal(agreements);
           callback();
         }]
       }, done);
     });
+
     it('returns two agreements from two events', function(done) {
       var agreementsAlpha = uuid();
       var agreementsBeta = uuid();
@@ -162,13 +256,13 @@ describe('bedrock-agreement', function() {
         }],
         test: ['getAccepted', function(callback, results) {
           var result = results.getAccepted;
-          result.should.be.an('array');
           result.should.have.length(2);
-          result.should.deep.equal([agreementsAlpha, agreementsBeta]);
+          result.should.have.same.members([agreementsAlpha, agreementsBeta]);
           callback();
         }]
       }, done);
     });
+
     it('returns five agreements from two events', function(done) {
       var agreementsAlpha = uuid();
       var agreementsBeta = [];
@@ -190,15 +284,37 @@ describe('bedrock-agreement', function() {
         }],
         test: ['getAccepted', function(callback, results) {
           var result = results.getAccepted;
-          result.should.be.an('array');
           result.should.have.length(5);
-          result.should.deep.equal(allAgreements);
+          result.should.have.same.members(allAgreements);
           callback();
         }]
       }, done);
     });
+
+    it('returns one agreement from two events', function(done) {
+      var agreementsAlpha = uuid();
+      var agreementsBeta = Array(4).fill(agreementsAlpha);
+      var actor = mockData.identities.regularUser.identity;
+      async.auto({
+        insertAlpha: function(callback) {
+          brAgreement.accept(actor, agreementsAlpha, callback);
+        },
+        insertBeta: ['insertAlpha', function(callback) {
+          brAgreement.accept(actor, agreementsBeta, callback);
+        }],
+        getAccepted: ['insertBeta', function(callback) {
+          brAgreement.getAccepted(actor, actor.id, callback);
+        }],
+        test: ['getAccepted', function(callback, results) {
+          var result = results.getAccepted;
+          result.should.have.length(1);
+          result.should.have.same.members([agreementsAlpha]);
+          callback();
+        }]
+      }, done);
+    });
+
     it('returns error if no AGREEMENT_ACCESS permission', function(done) {
-      var agreements = uuid();
       var actor = mockData.identities.noPermission.identity;
       brAgreement.getAccepted(actor, actor.id, function(err) {
         should.exist(err);
@@ -207,5 +323,17 @@ describe('bedrock-agreement', function() {
         done();
       });
     });
+
+    it('returns an error if actor is not a valid identity', function(done) {
+      var actor = null;
+      var id = mockData.identities.regularUser.identity.id;
+      brAgreement.getAccepted(actor, id, function(err) {
+        should.exist(err);
+        err.toString().should.equal(
+          'TypeError: actor must be an object with an "id" property.');
+        done();
+      });
+    });
+
   }); // end get
 });

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var async = require('async');
-var config = require('bedrock').config;
 var database = require('bedrock-mongodb');
 var uuid = require('uuid').v4;
 

--- a/test/package.json
+++ b/test/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "bedrock-agreement",
-  "version": "1.0.2-dev",
-  "description": "Bedrock agreement",
-  "main": "./lib",
+  "name": "bedrock-agreement-test",
+  "version": "0.0.1-0",
+  "description": "Bedrock agreement test",
+  "main": "./test",
+  "scripts": {
+    "test": "node --preserve-symlinks test test"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/digitalbazaar/bedrock-agreement"
@@ -21,15 +24,12 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-agreement",
   "dependencies": {
     "async": "^1.5.2",
-    "uuid": "^2.0.2"
-  },
-  "peerDependencies": {
     "bedrock": "^1.0.0",
     "bedrock-event-log": "^2.0.0",
     "bedrock-permission": "^2.3.0",
-    "bedrock-mongodb": "^3.0.0"
-  },
-  "directories": {
-    "lib": "./lib"
+    "bedrock-mongodb": "^3.0.0",
+    "bedrock-test": "^1.0.0",
+    "bedrock-validation": "^2.0.0",
+    "uuid": "^2.0.2"
   }
 }

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -9,7 +9,7 @@ require('bedrock-permission');
 var permissions = config.permission.permissions;
 var roles = config.permission.roles;
 
-config.mocha.tests.push(path.join(__dirname, '..', 'test', 'mocha'));
+config.mocha.tests.push(path.join(__dirname, 'mocha'));
 
 // MongoDB
 config.mongodb.name = 'bedrock_agreement_test';
@@ -22,7 +22,7 @@ config.mongodb.adminPrompt = true;
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
 
-roles['bedrock-agreement.test'] ={
+roles['bedrock-agreement.test'] = {
   id: 'bedrock-agreement.test',
   label: 'Agreement Test Role',
   comment: 'Role for Test User',

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2016 Digital Bazaar, Inc. All rights reserved.
  */
 var bedrock = require('bedrock');
-require('..');
+require('bedrock-agreement');
 
+require('bedrock-test');
 bedrock.start();


### PR DESCRIPTION
- getAccepted API will return unique values only.
- Adds the following tests to accept API:
  'accepts two identical agreements specified as strings'
  'accepts five agreements w/ same ID in an array'
  'returns error if agreements is not a string or array'
  'returns an error if actor is not a valid identity'
- Adds the following tests to getAccepted API:
  'returns empty array from no events'
  'returns one agreement from two events'
  'returns an error if actor is not a valid identity'
- Clean up some of the tests.
- Make error messages consistent.
- Make test names more consistent and descriptive.
